### PR TITLE
pass full path to log file as argument, use fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ deactivate
 ```
 
 ### test a ulog file 
-To test a specific ulog file, put that file into the `inputlog` directory. Make sure that only one file is present, otherwise the first file found will be chosen. (TODO improve how ulog files are read)
+To test a log file, pass its absolute path as a command line argument (see example below)
 
 All the tests are in the `tests` directory. Tests should be split into tests that apply for any ulog file and tests that are coupled to a specific simulated test.
 
 To run general tests:
 ```bash
-py.test tests/test_general.py
+py.test tests/test_general.py --filepath=absolute/path/to/logfile.ulg
 ```
 
 With the current default log, the test for tilt will fail because the vehicle flipped during the actual flight. 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,6 @@ def pytest_addoption(parser):
     )
 
 # With scope set to module, the fixture function only gets invoked once per module
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def filepath(request):
     return request.config.getoption("--filepath")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+# read arguments from command line if we want to run a pytest
+# the argument is stored and can be given as an argument to tests
+
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--filepath", action="store", default="Please pass absolute log file path as argument", help="absolute path to log file"
+    )
+
+@pytest.fixture
+def filepath(request):
+    return request.config.getoption("--filepath")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ def pytest_addoption(parser):
         "--filepath", action="store", default="Please pass absolute log file path as argument", help="absolute path to log file"
     )
 
-@pytest.fixture
+# With scope set to module, the fixture function only gets invoked once per module
+@pytest.fixture(scope="module")
 def filepath(request):
     return request.config.getoption("--filepath")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def filepath(request):
     return request.config.getoption("--filepath")
 
     
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def filecheck(filepath):
     # ensure it is a ulg file
     base, ext = os.path.splitext(filepath)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 # the argument is stored and can be given as an argument to tests
 
 import pytest
+import os
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -9,6 +11,14 @@ def pytest_addoption(parser):
     )
 
 # With scope set to module, the fixture function only gets invoked once per module
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session")
 def filepath(request):
     return request.config.getoption("--filepath")
+
+    
+@pytest.fixture(scope="session")
+def filecheck(filepath):
+    # ensure it is a ulg file
+    base, ext = os.path.splitext(filepath)
+    if ext.lower() not in (".ulg") or not filepath:
+        pytest.exit("passed file is not a .ulg file.")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -64,7 +64,7 @@ class TestRTLHeight:
         ]
         self.ulog = pyulog.ULog(filepath, topics)
         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-        
+
 
     def test_rtl(self, filecheck, filepath):
 
@@ -123,18 +123,18 @@ class TestRTLHeight:
 
 
 # class TestSomething:
+# 
+    # def setup_dataframe(self, filepath):
+    #     topics = [
+    #         "topic1",
+    #         "topic2",
+    #     ]
+    #     self.ulog = pyulog.ULog(filepath, topics)
+    #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 #
-#    def test_1(self, filepath):
-        # topics = [
-            # "topic1",
-            # "topic2",
-        # ]
-        # file_path(self, topics, filepath)
+    # def test_1(self, filepath):
+        # TestSomething.setup_dataframe(self, filepath)
 #        assert True
 #    def test_2(self, filepath):
-        # topics = [
-            # "topic1",
-            # "topic2",
-        # ]
-        # file_path(self, topics, filepath)
+        # TestSomething.setup_dataframe(self, filepath)
 #        assert True

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -28,7 +28,7 @@ class TestAttitude:
         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
     
-    def test_tilt_desired(self, filecheck, filepath):
+    def test_tilt_desired(self, filepath):
 
         TestAttitude.setup_dataframe(self, filepath)
 
@@ -66,7 +66,7 @@ class TestRTLHeight:
         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
 
-    def test_rtl(self, filecheck, filepath):
+    def test_rtl(self, filepath):
 
         TestRTLHeight.setup_dataframe(self, filepath)
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -12,15 +12,12 @@ import os
 import numpy as np
 import pytest
 
-
-def file_path(self, topics, filepath):
-    self.ulog = pyulog.ULog(filepath, topics)
-    self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
+@pytest.fixture(scope="module")
+def filecheck(filepath):
     # ensure it is a ulg file
     base, ext = os.path.splitext(filepath)
     if ext.lower() not in (".ulg") or not filepath:
-        pytest.exit("Either no file present or not an .ulg file.")
+        pytest.exit("passed file is not a .ulg file.")
 
 
 class TestAttitude:
@@ -28,13 +25,14 @@ class TestAttitude:
     Test Attitude related constraints
     """
 
-    def test_tilt_desired(self, filepath):
+    def test_tilt_desired(self, filecheck, filepath):
         topics = [
             "vehicle_attitude",
             "vehicle_attitude_setpoint",
             "vehicle_status",
         ]
-        file_path(self, topics, filepath)
+        self.ulog = pyulog.ULog(filepath, topics)
+        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
         # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
         # MPC_MAN_TILT_MAX
@@ -61,13 +59,14 @@ class TestRTLHeight:
     # check the height above ground while the drone returns to home. compare it with 
     # the allowed maximum or minimum heights, until the drone has reached home and motors have been turned off
 
-   def test_rtl(self, filepath):
+   def test_rtl(self, filecheck, filepath):
         # set up class
         topics = [
             "vehicle_local_position",
             "vehicle_status",
         ]
-        file_path(self, topics, filepath)
+        self.ulog = pyulog.ULog(filepath, topics)
+        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
         # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
         rtl_min_dist = (

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -12,21 +12,10 @@ import os
 import numpy as np
 import pytest
 
+def setup_class(self, topics, filepath):
+    self.ulog = pyulog.ULog(filepath, topics)
+    self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
-def getfilepath():
-    currentpath = os.path.dirname(os.path.realpath(__file__))
-    for f in os.listdir(currentpath + "/../inputlog"):
-        if f:
-            filepath = f
-            break
-    return currentpath + "/../inputlog/" + filepath
-
-
-def setup_module(module):
-    """
-    Check if file exists. Otherwise don't bother to run all the tests
-    """
-    filepath = getfilepath()
     # ensure it is a ulg file
     base, ext = os.path.splitext(filepath)
     if ext.lower() not in (".ulg") or not filepath:
@@ -38,17 +27,13 @@ class TestAttitude:
     Test Attitude related constraints
     """
 
-    def setup_class(self):
-        filepath = getfilepath()
+    def test_tilt_desired(self, filepath):
         topics = [
             "vehicle_attitude",
             "vehicle_attitude_setpoint",
             "vehicle_status",
         ]
-        self.ulog = pyulog.ULog(filepath, topics)
-        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-    def test_tilt_desired(self):
+        setup_class(self, topics, filepath)
 
         # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
         # MPC_MAN_TILT_MAX
@@ -75,18 +60,14 @@ class TestRTLHeight:
     # check the height above ground while the drone returns to home. compare it with 
     # the allowed maximum or minimum heights, until the drone has reached home and motors have been turned off
 
-   def setup_class(self):
-        # get the required data
-        filepath = getfilepath()
+   def test_rtl(self, filepath):
+        # set up class
         topics = [
             "vehicle_local_position",
             "vehicle_status",
         ]
-        self.ulog = pyulog.ULog(filepath, topics)
-        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+        setup_class(self, topics, filepath)
 
-
-   def test_rtl(self):
         # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
         rtl_min_dist = (
             loginfo.get_param(self.ulog, "RTL_MIN_DIST", 0)
@@ -108,7 +89,8 @@ class TestRTLHeight:
         state_group = self.df.groupby(['T_vehicle_status_0__F_nav_state_group2'])
         for g, d in state_group:
             # Check that RTL was actually triggered 
-            # at least two consecutive T_vehicle_status_0__F_nav_state values have to be equal to NAVIGATION_STATE_AUTO_RTL in order to confirm that RTL has been triggered
+            # at least two consecutive T_vehicle_status_0__F_nav_state values have to 
+            # be equal to NAVIGATION_STATE_AUTO_RTL in order to confirm that RTL has been triggered
             if d.T_vehicle_status_0__F_nav_state.count() > 1 and d.T_vehicle_status_0__F_nav_state[0] == NAVIGATION_STATE_AUTO_RTL:
                 height_at_RTL = abs(d.T_vehicle_local_position_0__F_z[0])
                 distance_at_RTL = d.T_vehicle_local_position_0__NF_abs_horizontal_dist[0]
@@ -140,16 +122,17 @@ class TestRTLHeight:
 
 # class TestSomething:
 #
-#    def setup_class(self):
-#        # get the required data
-#        filepath = getfilepath()
-#        topics = [
-#            ""
-#        ]
-#        self.ulog = pyulog.ULog(filepath, topics)
-#        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-#
-#    def test_1(self):
+#    def test_1(self, filepath):
+        # topics = [
+            # "topic1",
+            # "topic2",
+        # ]
+        # setup_class(self, topics, filepath)
 #        assert True
-#    def test_2(self):
+#    def test_2(self, filepath):
+        # topics = [
+            # "topic1",
+            # "topic2",
+        # ]
+        # setup_class(self, topics, filepath)
 #        assert True

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 
 
-
 class TestAttitude:
     """
     Test Attitude related constraints

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -12,7 +12,8 @@ import os
 import numpy as np
 import pytest
 
-def setup_class(self, topics, filepath):
+
+def file_path(self, topics, filepath):
     self.ulog = pyulog.ULog(filepath, topics)
     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
@@ -33,7 +34,7 @@ class TestAttitude:
             "vehicle_attitude_setpoint",
             "vehicle_status",
         ]
-        setup_class(self, topics, filepath)
+        file_path(self, topics, filepath)
 
         # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
         # MPC_MAN_TILT_MAX
@@ -66,7 +67,7 @@ class TestRTLHeight:
             "vehicle_local_position",
             "vehicle_status",
         ]
-        setup_class(self, topics, filepath)
+        file_path(self, topics, filepath)
 
         # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
         rtl_min_dist = (
@@ -127,12 +128,12 @@ class TestRTLHeight:
             # "topic1",
             # "topic2",
         # ]
-        # setup_class(self, topics, filepath)
+        # file_path(self, topics, filepath)
 #        assert True
 #    def test_2(self, filepath):
         # topics = [
             # "topic1",
             # "topic2",
         # ]
-        # setup_class(self, topics, filepath)
+        # file_path(self, topics, filepath)
 #        assert True

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -12,19 +12,13 @@ import os
 import numpy as np
 import pytest
 
-@pytest.fixture(scope="module")
-def filecheck(filepath):
-    # ensure it is a ulg file
-    base, ext = os.path.splitext(filepath)
-    if ext.lower() not in (".ulg") or not filepath:
-        pytest.exit("passed file is not a .ulg file.")
 
 
 class TestAttitude:
     """
     Test Attitude related constraints
     """
-
+    
     def test_tilt_desired(self, filecheck, filepath):
         topics = [
             "vehicle_attitude",

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -17,8 +17,8 @@ class TestAttitude:
     """
     Test Attitude related constraints
     """
-    
-    def test_tilt_desired(self, filecheck, filepath):
+
+    def setup_dataframe(self, filepath):
         topics = [
             "vehicle_attitude",
             "vehicle_attitude_setpoint",
@@ -26,6 +26,11 @@ class TestAttitude:
         ]
         self.ulog = pyulog.ULog(filepath, topics)
         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+
+    
+    def test_tilt_desired(self, filecheck, filepath):
+
+        TestAttitude.setup_dataframe(self, filepath)
 
         # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
         # MPC_MAN_TILT_MAX
@@ -52,14 +57,18 @@ class TestRTLHeight:
     # check the height above ground while the drone returns to home. compare it with 
     # the allowed maximum or minimum heights, until the drone has reached home and motors have been turned off
 
-   def test_rtl(self, filecheck, filepath):
-        # set up class
+    def setup_dataframe(self, filepath):
         topics = [
             "vehicle_local_position",
             "vehicle_status",
         ]
         self.ulog = pyulog.ULog(filepath, topics)
         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+        
+
+    def test_rtl(self, filecheck, filepath):
+
+        TestRTLHeight.setup_dataframe(self, filepath)
 
         # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
         rtl_min_dist = (

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -10,29 +10,20 @@ import os
 import numpy as np
 import pytest
 
-def file_path(self, topics, filepath):
-    self.ulog = pyulog.ULog(filepath, topics)
-    self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-    # ensure it is a ulg file
-    base, ext = os.path.splitext(filepath)
-    if ext.lower() not in (".ulg") or not filepath:
-        pytest.exit("Either no file present or not an .ulg file.")
-
 
 # class TestSomething:
+# 
+    # def setup_dataframe(self, filepath):
+    #     topics = [
+    #         "topic1",
+    #         "topic2",
+    #     ]
+    #     self.ulog = pyulog.ULog(filepath, topics)
+    #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 #
-#    def test_1(self, filepath):
-        # topics = [
-            # "topic1",
-            # "topic2",
-        # ]
-        # file_path(self, topics, filepath)
+    # def test_1(self, filepath):
+        # TestSomething.setup_dataframe(self, filepath)
 #        assert True
 #    def test_2(self, filepath):
-        # topics = [
-            # "topic1",
-            # "topic2",
-        # ]
-        # file_path(self, topics, filepath)
+        # TestSomething.setup_dataframe(self, filepath)
 #        assert True

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -10,40 +10,24 @@ import os
 import numpy as np
 import pytest
 
+def setup_class(self, topics, filepath):
+    self.ulog = pyulog.ULog(filepath, topics)
+    self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
-def getfilepath():
-    currentpath = os.path.dirname(os.path.realpath(__file__))
-    for f in os.listdir(currentpath + "/../inputlog"):
-        if f:
-            filepath = f
-            break
-    return currentpath + "/../inputlog/" + filepath
-
-
-def setup_module(module):
-    """
-    Check if file exists. Otherwise don't bother to run all the tests
-    """
-    filepath = getfilepath()
     # ensure it is a ulg file
     base, ext = os.path.splitext(filepath)
     if ext.lower() not in (".ulg") or not filepath:
         pytest.exit("Either no file present or not an .ulg file.")
 
 
-
 # class TestSomething:
 #
-#    def setup_class(self):
-#        # get the required data
-#        filepath = getfilepath()
-#        topics = [
-#            ""
-#        ]
-#        self.ulog = pyulog.ULog(filepath, topics)
-#        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-#
-#    def test_1(self):
+#    def test_1(self, filepath):
+        # topics = [
+            # "topic1",
+            # "topic2",
+        # ]
+        # setup_class(self, topics, filepath)
 #        assert True
-#    def test_2(self):
+#    def test_2(self, filepath):
 #        assert True

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -10,7 +10,7 @@ import os
 import numpy as np
 import pytest
 
-def setup_class(self, topics, filepath):
+def file_path(self, topics, filepath):
     self.ulog = pyulog.ULog(filepath, topics)
     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
@@ -27,7 +27,12 @@ def setup_class(self, topics, filepath):
             # "topic1",
             # "topic2",
         # ]
-        # setup_class(self, topics, filepath)
+        # file_path(self, topics, filepath)
 #        assert True
 #    def test_2(self, filepath):
+        # topics = [
+            # "topic1",
+            # "topic2",
+        # ]
+        # file_path(self, topics, filepath)
 #        assert True


### PR DESCRIPTION
By using fixtures, it is now possible to pass the full path to a log file as a command line argument. A fixture is also used to check if the passed path actually belongs to a log file or not. The file conftest.py is home to to the fixtures. The scope of the fixtures was set to "session", thus they only get called once per session. However, they still have to be passed as arguments to the different functions that need the fixtures! The fixture 'filecheck' is set to autouse, thus it is automatically called and does not have to be passed as an argument to a test (since its only task is to do a background check whether the passed file is actually a log file or not).