### PR TITLE
Ulog file topics are automatically checked for existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ All the tests are in the `tests` directory. Tests should be split into tests tha
 
 To run general tests:
 ```bash
-py.test tests/test_general.py --filepath=absolute/path/to/logfile.ulg
+py.test -s tests/test_general.py --filepath=absolute/path/to/logfile.ulg
 ```
+
+Using -s allows you to see print statements for the skipped tests
 
 With the current default log, the test for tilt will fail because the vehicle flipped during the actual flight. 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@ def pytest_addoption(parser):
 def filepath(request):
     return request.config.getoption("--filepath")
 
-    
+
+# This fixture is run automatically, so it does not have to be called explicitely (because of autouse)    
 @pytest.fixture(scope="session", autouse=True)
 def filecheck(filepath):
     # ensure it is a ulg file

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -24,42 +24,49 @@ class TestAttitude:
             "vehicle_attitude_setpoint",
             "vehicle_status",
         ]
-        self.ulog = pyulog.ULog(filepath, topics)
-        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+
+        # Check if any of the topics exist in the topics exists in the log file
+        try:
+            self.ulog = pyulog.ULog(filepath, topics)
+        except:
+            print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
+            assert False
+
+        # Check for every topic separately if it exists in the log file
+        data_list_names = []
+        for i in range(len(self.ulog.data_list)):
+            data_list_names.append(self.ulog.data_list[i].name)
+
+        # check if the number of elements in the two list is the same. If it is not, 
+        # then some topics went missing!
+        if len(topics) != len(data_list_names):
+            print("A needed topic does not exist in the provided ulog file. Abort test.")
+            assert False
+        else:
+            self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
     
     def test_tilt_desired(self, filepath):
 
         TestAttitude.setup_dataframe(self, filepath)
+    
+        # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
+        # MPC_MAN_TILT_MAX
 
-        # check if needed messages actually exist in dataframe (check also for messages that are needed to create new messages!)
-        if "T_vehicle_status_0__F_nav_state" not in self.df or \
-        "T_vehicle_attitude_setpoint_0__F_q_d_0" not in self.df or \
-        "T_vehicle_attitude_setpoint_0__F_q_d_1" not in self.df or \
-        "T_vehicle_attitude_setpoint_0__F_q_d_2" not in self.df or \
-        "T_vehicle_attitude_setpoint_0__F_q_d_3" not in self.df:
-            print("One or several messages that are needed for this test were not available in the provided log file!")
-            # pytest.skip("missing message")
-            assert False
-
-        else:
-            # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
-            # MPC_MAN_TILT_MAX
-
-            attanl.add_desired_tilt(self.df)
-            man_tilt = (
-                loginfo.get_param(self.ulog, "MPC_MAN_TILT_MAX", 0) * np.pi / 180
+        attanl.add_desired_tilt(self.df)
+        man_tilt = (
+            loginfo.get_param(self.ulog, "MPC_MAN_TILT_MAX", 0) * np.pi / 180
+        )
+        assert self.df[
+            (
+                (self.df.T_vehicle_status_0__F_nav_state == 0)
+                | (self.df.T_vehicle_status_0__F_nav_state == 1)
             )
-            assert self.df[
-                (
-                    (self.df.T_vehicle_status_0__F_nav_state == 0)
-                    | (self.df.T_vehicle_status_0__F_nav_state == 1)
-                )
-                & (
-                    self.df.T_vehicle_attitude_setpoint_0__NF_tilt_desired
-                    > man_tilt
-                )
-            ].empty
+            & (
+                self.df.T_vehicle_attitude_setpoint_0__NF_tilt_desired
+                > man_tilt
+            )
+        ].empty
 
 
 class TestRTLHeight:
@@ -73,90 +80,80 @@ class TestRTLHeight:
             "vehicle_local_position",
             "vehicle_status",
         ]
-        self.ulog = pyulog.ULog(filepath, topics)
-        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+
+        # Check if any of the topics exist in the topics exists in the log file
+        try:
+            self.ulog = pyulog.ULog(filepath, topics)
+        except:
+            print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
+            assert False
+
+        # Check for every topic separately if it exists in the log file
+        data_list_names = []
+        for i in range(len(self.ulog.data_list)):
+            data_list_names.append(self.ulog.data_list[i].name)
+
+        # check if the number of elements in the two list is the same. If it is not, 
+        # then some topics went missing!
+        if len(topics) != len(data_list_names):
+            print("A needed topic does not exist in the provided ulog file. Abort test.")
+            assert False
+        else:
+            self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
 
     def test_rtl(self, filepath):
 
         TestRTLHeight.setup_dataframe(self, filepath)
 
-        # check if needed messages actually exist in dataframe (check also for messages that are needed to create new messages!)
-        if "T_vehicle_status_0__F_nav_state" not in self.df or \
-        "T_vehicle_local_position_0__F_x" not in self.df or \
-        "T_vehicle_local_position_0__F_y" not in self.df or \
-        "T_vehicle_local_position_0__F_z" not in self.df:
-            print("One or several messages that are needed for this test were not available in the provided log file!")
-            # pytest.skip("missing message")
-            assert False
+        # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
+        rtl_min_dist = (
+            loginfo.get_param(self.ulog, "RTL_MIN_DIST", 0)
+        )
+        rtl_return_alt = (
+            loginfo.get_param(self.ulog, "RTL_RETURN_ALT", 0)
+        )
+        rtl_cone_dist = (
+            loginfo.get_param(self.ulog, "RTL_CONE_DIST", 0)
+        )
 
-        else:
-            # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
-            rtl_min_dist = (
-                loginfo.get_param(self.ulog, "RTL_MIN_DIST", 0)
-            )
-            rtl_return_alt = (
-                loginfo.get_param(self.ulog, "RTL_RETURN_ALT", 0)
-            )
-            rtl_cone_dist = (
-                loginfo.get_param(self.ulog, "RTL_CONE_DIST", 0)
-            )
+        NAVIGATION_STATE_AUTO_RTL = 5           # see https://github.com/PX4/Firmware/blob/master/msg/vehicle_status.msg
+        thresh = 1                              # Threshold for position inaccuracies, in meters
 
-            NAVIGATION_STATE_AUTO_RTL = 5           # see https://github.com/PX4/Firmware/blob/master/msg/vehicle_status.msg
-            thresh = 1                              # Threshold for position inaccuracies, in meters
+        posanl.add_horizontal_distance(self.df)
 
-            posanl.add_horizontal_distance(self.df)
+        # Run the test every time that RTL was triggered
+        self.df['T_vehicle_status_0__F_nav_state_group2'] = (self.df.T_vehicle_status_0__F_nav_state != self.df.T_vehicle_status_0__F_nav_state.shift()).cumsum()
+        state_group = self.df.groupby(['T_vehicle_status_0__F_nav_state_group2'])
+        for g, d in state_group:
+            # Check that RTL was actually triggered 
+            # at least two consecutive T_vehicle_status_0__F_nav_state values have to 
+            # be equal to NAVIGATION_STATE_AUTO_RTL in order to confirm that RTL has been triggered
+            if d.T_vehicle_status_0__F_nav_state.count() > 1 and d.T_vehicle_status_0__F_nav_state[0] == NAVIGATION_STATE_AUTO_RTL:
+                height_at_RTL = abs(d.T_vehicle_local_position_0__F_z[0])
+                distance_at_RTL = d.T_vehicle_local_position_0__NF_abs_horizontal_dist[0]
+                max_height_during_RTL = abs(max(d.T_vehicle_local_position_0__F_z))
 
-            # Run the test every time that RTL was triggered
-            self.df['T_vehicle_status_0__F_nav_state_group2'] = (self.df.T_vehicle_status_0__F_nav_state != self.df.T_vehicle_status_0__F_nav_state.shift()).cumsum()
-            state_group = self.df.groupby(['T_vehicle_status_0__F_nav_state_group2'])
-            for g, d in state_group:
-                # Check that RTL was actually triggered 
-                # at least two consecutive T_vehicle_status_0__F_nav_state values have to 
-                # be equal to NAVIGATION_STATE_AUTO_RTL in order to confirm that RTL has been triggered
-                if d.T_vehicle_status_0__F_nav_state.count() > 1 and d.T_vehicle_status_0__F_nav_state[0] == NAVIGATION_STATE_AUTO_RTL:
-                    height_at_RTL = abs(d.T_vehicle_local_position_0__F_z[0])
-                    distance_at_RTL = d.T_vehicle_local_position_0__NF_abs_horizontal_dist[0]
-                    max_height_during_RTL = abs(max(d.T_vehicle_local_position_0__F_z))
+                if rtl_cone_dist > 0:
+                    # Drone should not rise higher than height defined by a cone (definition taken from rtl.cpp file in firmware)
+                    max_height_within_RTL_MIN_DIST = 2 * distance_at_RTL
+                else:
+                    # If no cone is defined, drone should not rise at all within certain radius around home
+                    max_height_within_RTL_MIN_DIST = height_at_RTL
+                
+                # check if a value of the z position after triggering RTL is larger than allowed value
+                if (distance_at_RTL < rtl_min_dist) & (height_at_RTL < max_height_within_RTL_MIN_DIST):
+                    assert max_height_during_RTL < max_height_within_RTL_MIN_DIST + thresh
 
-                    if rtl_cone_dist > 0:
-                        # Drone should not rise higher than height defined by a cone (definition taken from rtl.cpp file in firmware)
-                        max_height_within_RTL_MIN_DIST = 2 * distance_at_RTL
-                    else:
-                        # If no cone is defined, drone should not rise at all within certain radius around home
-                        max_height_within_RTL_MIN_DIST = height_at_RTL
-                    
-                    # check if a value of the z position after triggering RTL is larger than allowed value
-                    if (distance_at_RTL < rtl_min_dist) & (height_at_RTL < max_height_within_RTL_MIN_DIST):
-                        assert max_height_during_RTL < max_height_within_RTL_MIN_DIST + thresh
+                elif (distance_at_RTL < rtl_min_dist) & (height_at_RTL >= max_height_within_RTL_MIN_DIST): 
+                    assert max_height_during_RTL < height_at_RTL + thresh
 
-                    elif (distance_at_RTL < rtl_min_dist) & (height_at_RTL >= max_height_within_RTL_MIN_DIST): 
-                        assert max_height_during_RTL < height_at_RTL + thresh
+                elif (distance_at_RTL >= rtl_min_dist) & (height_at_RTL < rtl_return_alt): 
+                    assert max_height_during_RTL < rtl_return_alt + thresh
 
-                    elif (distance_at_RTL >= rtl_min_dist) & (height_at_RTL < rtl_return_alt): 
-                        assert max_height_during_RTL < rtl_return_alt + thresh
-
-                    elif (distance_at_RTL >= rtl_min_dist) & (height_at_RTL > rtl_return_alt): 
-                        assert max_height_during_RTL < height_at_RTL + thresh
+                elif (distance_at_RTL >= rtl_min_dist) & (height_at_RTL > rtl_return_alt): 
+                    assert max_height_during_RTL < height_at_RTL + thresh
                         
-
-# class TestBlabla:
-
-#     def setup_dataframe(self, filepath):
-#         topics = [
-#             "vehicle_status",
-#             "blabla"
-#         ]
-#         self.ulog = pyulog.ULog(filepath, topics)
-#         self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-#         print(list(self.df))
-
-#     def test_1(self, filepath):
-#         TestBlabla.setup_dataframe(self, filepath)
-#         assert True
-
-
 
 
 # class TestSomething:
@@ -166,8 +163,26 @@ class TestRTLHeight:
     #         "topic1",
     #         "topic2",
     #     ]
-    #     self.ulog = pyulog.ULog(filepath, topics)
-    #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+            # Check if any of the topics exist in the topics exists in the log file
+        # try:
+        #     self.ulog = pyulog.ULog(filepath, topics)
+        # except:
+        #     print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
+        #     assert False
+
+        # # Check for every topic separately if it exists in the log file
+        # data_list_names = []
+        # for i in range(len(self.ulog.data_list)):
+        #     data_list_names.append(self.ulog.data_list[i].name)
+
+        # # check if the number of elements in the two list is the same. If it is not, 
+        # # then some topics went missing!
+        # if len(topics) != len(data_list_names):
+        #     print("A needed topic does not exist in the provided ulog file. Abort test.")
+        #     assert False
+        # else:
+        #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+
 #
     # def test_1(self, filepath):
         # TestSomething.setup_dataframe(self, filepath)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -13,43 +13,43 @@ import numpy as np
 import pytest
 
 
+def setup_dataframe(self, filepath, topics):
+    # Check if any of the topics exist in the topics exists in the log file
+    try:
+        self.ulog = pyulog.ULog(filepath, topics)
+    except:
+        print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
+        assert False
+
+    # Check for every topic separately if it exists in the log file
+    for i in range(len(self.ulog.data_list)):
+        if self.ulog.data_list[i].name in topics:
+            idx = topics.index(self.ulog.data_list[i].name)
+            topics.pop(idx)
+
+    if len(topics) > 0:
+        print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
+        print(topics)
+        pytest.skip("Skip this test because topics are missing")
+    else:
+        self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+    
+    # return self
+
+
 class TestAttitude:
     """
     Test Attitude related constraints
     """
+    def test_tilt_desired(self, filepath):
 
-    def setup_dataframe(self, filepath):
         topics = [
             "vehicle_attitude",
             "vehicle_attitude_setpoint",
             "vehicle_status",
-            "bafd"
         ]
 
-        # Check if any of the topics exist in the topics exists in the log file
-        try:
-            self.ulog = pyulog.ULog(filepath, topics)
-        except:
-            print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
-            assert False
-
-        # Check for every topic separately if it exists in the log file
-        for i in range(len(self.ulog.data_list)):
-            if self.ulog.data_list[i].name in topics:
-                idx = topics.index(self.ulog.data_list[i].name)
-                topics.pop(idx)
-
-        if len(topics) > 0:
-            print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
-            print(topics)
-            pytest.skip("Skip this test because topics are missing")
-        else:
-            self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-    
-    def test_tilt_desired(self, filepath):
-
-        TestAttitude.setup_dataframe(self, filepath)
+        setup_dataframe(self, filepath, topics)
     
         # During Manual / Stabilized and Altitude, the tilt threshdol should not exceed
         # MPC_MAN_TILT_MAX
@@ -76,36 +76,14 @@ class TestRTLHeight:
     # check the height above ground while the drone returns to home. compare it with 
     # the allowed maximum or minimum heights, until the drone has reached home and motors have been turned off
 
-    def setup_dataframe(self, filepath):
+    def test_rtl(self, filepath):
+
         topics = [
             "vehicle_local_position",
             "vehicle_status",
         ]
 
-        # Check if any of the topics exist in the topics exists in the log file
-        try:
-            self.ulog = pyulog.ULog(filepath, topics)
-        except:
-            print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
-            assert False
-
-        # Check for every topic separately if it exists in the log file
-        for i in range(len(self.ulog.data_list)):
-            if self.ulog.data_list[i].name in topics:
-                idx = topics.index(self.ulog.data_list[i].name)
-                topics.pop(idx)
-
-        if len(topics) > 0:
-            print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
-            print(topics)
-            pytest.skip("Skip this test because topics are missing")
-        else:
-            self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-
-    def test_rtl(self, filepath):
-
-        TestRTLHeight.setup_dataframe(self, filepath)
+        setup_dataframe(self, filepath, topics)
 
         # drone parameters: below rtl_min_dist, the drone follows different rules than outside of it.
         rtl_min_dist = (
@@ -158,35 +136,18 @@ class TestRTLHeight:
 
 
 # class TestSomething:
-# 
-    # def setup_dataframe(self, filepath):
+#
+    # def test_1(self, filepath):
     #     topics = [
     #         "topic1",
     #         "topic2",
     #     ]
-            # Check if any of the topics exist in the topics exists in the log file
-        # try:
-        #     self.ulog = pyulog.ULog(filepath, topics)
-        # except:
-        #     print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
-        #     assert False
-
-        # # Check for every topic separately if it exists in the log file
-        # for i in range(len(self.ulog.data_list)):
-        #     if self.ulog.data_list[i].name in topics:
-        #         idx = topics.index(self.ulog.data_list[i].name)
-        #         topics.pop(idx)
-
-        # if len(topics) > 0:
-        #     print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
-        #     print(topics)
-        #     pytest.skip("Skip this test because topics are missing")
-        # else:
-        #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-#
-    # def test_1(self, filepath):
-        # TestSomething.setup_dataframe(self, filepath)
+    #    setup_dataframe(self, filepath)
 #        assert True
 #    def test_2(self, filepath):
-        # TestSomething.setup_dataframe(self, filepath)
+    #     topics = [
+    #         "topic1",
+    #         "topic2",
+    #     ]
+        # setup_dataframe(self, filepath)
 #        assert True

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -23,6 +23,7 @@ class TestAttitude:
             "vehicle_attitude",
             "vehicle_attitude_setpoint",
             "vehicle_status",
+            "bafd"
         ]
 
         # Check if any of the topics exist in the topics exists in the log file
@@ -33,15 +34,15 @@ class TestAttitude:
             assert False
 
         # Check for every topic separately if it exists in the log file
-        data_list_names = []
         for i in range(len(self.ulog.data_list)):
-            data_list_names.append(self.ulog.data_list[i].name)
+            if self.ulog.data_list[i].name in topics:
+                idx = topics.index(self.ulog.data_list[i].name)
+                topics.pop(idx)
 
-        # check if the number of elements in the two list is the same. If it is not, 
-        # then some topics went missing!
-        if len(topics) != len(data_list_names):
-            print("A needed topic does not exist in the provided ulog file. Abort test.")
-            assert False
+        if len(topics) > 0:
+            print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
+            print(topics)
+            pytest.skip("Skip this test because topics are missing")
         else:
             self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
@@ -89,15 +90,15 @@ class TestRTLHeight:
             assert False
 
         # Check for every topic separately if it exists in the log file
-        data_list_names = []
         for i in range(len(self.ulog.data_list)):
-            data_list_names.append(self.ulog.data_list[i].name)
+            if self.ulog.data_list[i].name in topics:
+                idx = topics.index(self.ulog.data_list[i].name)
+                topics.pop(idx)
 
-        # check if the number of elements in the two list is the same. If it is not, 
-        # then some topics went missing!
-        if len(topics) != len(data_list_names):
-            print("A needed topic does not exist in the provided ulog file. Abort test.")
-            assert False
+        if len(topics) > 0:
+            print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
+            print(topics)
+            pytest.skip("Skip this test because topics are missing")
         else:
             self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
 
@@ -171,18 +172,17 @@ class TestRTLHeight:
         #     assert False
 
         # # Check for every topic separately if it exists in the log file
-        # data_list_names = []
         # for i in range(len(self.ulog.data_list)):
-        #     data_list_names.append(self.ulog.data_list[i].name)
+        #     if self.ulog.data_list[i].name in topics:
+        #         idx = topics.index(self.ulog.data_list[i].name)
+        #         topics.pop(idx)
 
-        # # check if the number of elements in the two list is the same. If it is not, 
-        # # then some topics went missing!
-        # if len(topics) != len(data_list_names):
-        #     print("A needed topic does not exist in the provided ulog file. Abort test.")
-        #     assert False
+        # if len(topics) > 0:
+        #     print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
+        #     print(topics)
+        #     pytest.skip("Skip this test because topics are missing")
         # else:
         #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
 #
     # def test_1(self, filepath):
         # TestSomething.setup_dataframe(self, filepath)

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -12,36 +12,18 @@ import pytest
 
 
 # class TestSomething:
-# 
-    # def setup_dataframe(self, filepath):
+#
+    # def test_1(self, filepath):
     #     topics = [
     #         "topic1",
     #         "topic2",
     #     ]
-            # Check if any of the topics exist in the topics exists in the log file
-        # try:
-        #     self.ulog = pyulog.ULog(filepath, topics)
-        # except:
-        #     print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
-        #     assert False
-
-        # # Check for every topic separately if it exists in the log file
-        # for i in range(len(self.ulog.data_list)):
-        #     if self.ulog.data_list[i].name in topics:
-        #         idx = topics.index(self.ulog.data_list[i].name)
-        #         topics.pop(idx)
-
-        # if len(topics) > 0:
-        #     print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
-        #     print(topics)
-        #     pytest.skip("Skip this test because topics are missing")
-        # else:
-        #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
-
-#
-    # def test_1(self, filepath):
-        # TestSomething.setup_dataframe(self, filepath)
+    #    setup_dataframe(self, filepath)
 #        assert True
 #    def test_2(self, filepath):
-        # TestSomething.setup_dataframe(self, filepath)
+    #     topics = [
+    #         "topic1",
+    #         "topic2",
+    #     ]
+        # setup_dataframe(self, filepath)
 #        assert True

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -18,8 +18,26 @@ import pytest
     #         "topic1",
     #         "topic2",
     #     ]
-    #     self.ulog = pyulog.ULog(filepath, topics)
-    #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+            # Check if any of the topics exist in the topics exists in the log file
+        # try:
+        #     self.ulog = pyulog.ULog(filepath, topics)
+        # except:
+        #     print("Not a single topic that is needed for this test exists in the provided ulog file. Abort test")
+        #     assert False
+
+        # # Check for every topic separately if it exists in the log file
+        # for i in range(len(self.ulog.data_list)):
+        #     if self.ulog.data_list[i].name in topics:
+        #         idx = topics.index(self.ulog.data_list[i].name)
+        #         topics.pop(idx)
+
+        # if len(topics) > 0:
+        #     print("\033[93m" + "The following topics do not exist in the provided ulog file: " + "\033[0m")
+        #     print(topics)
+        #     pytest.skip("Skip this test because topics are missing")
+        # else:
+        #     self.df = ulogconv.merge(ulogconv.createPandaDict(self.ulog))
+
 #
     # def test_1(self, filepath):
         # TestSomething.setup_dataframe(self, filepath)


### PR DESCRIPTION
Since it can happen that Ulog files are missing some topics, we need to check whether they exist before we do a test. For every test, a check is performed to see if all needed topics are available in the ulog file. If a topic is missing, the test gets skipped and a message is printed to the console, stating the missing topic (argument -s has to be used in order to show print statements, see also the README file). 